### PR TITLE
Add JavaDoc to every enum value which allows the user to see the color.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 colors.iml
 gradle
 signing.properties
+/.nb-gradle/

--- a/src/main/java/eu/hansolo/colors/ColorHelper.java
+++ b/src/main/java/eu/hansolo/colors/ColorHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016 by Gerrit Grunwald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.hansolo.colors;
+
+import javafx.scene.paint.Color;
+
+/**
+ *
+ * Created by Naoghuman on 12.01.16.
+ */
+public class ColorHelper {
+    
+    private static String hexRed;
+    private static String hexGreen;
+    private static String hexBlue;
+    private static String intRed;
+    private static String intGreen;
+    private static String intBlue;
+
+   public static String rgb(Color color) {
+       convert(color);
+       
+       final StringBuilder sb = new StringBuilder();
+       sb.append("rgb(");
+       sb.append(intRed);
+       sb.append(", ");
+       sb.append(intGreen);
+       sb.append(", ");
+       sb.append(intBlue);
+       sb.append(")");
+
+       return sb.toString();
+   }
+
+   public static String web(Color color) {
+       convert(color);
+       
+       final StringBuilder sb = new StringBuilder();
+       sb.append("#");
+       sb.append(hexRed);
+       sb.append(hexGreen);
+       sb.append(hexBlue);
+
+       return sb.toString();
+   }
+   
+   private static void convert(Color color) {
+        final String hex = color.toString().replace("0x", "");
+        hexRed   = hex.substring(0, 2).toUpperCase();
+        hexGreen = hex.substring(2, 4).toUpperCase();
+        hexBlue  = hex.substring(4, 6).toUpperCase();
+
+        intRed   = Integer.toString(Integer.parseInt(hexRed, 16));
+        intGreen = Integer.toString(Integer.parseInt(hexGreen, 16));
+        intBlue  = Integer.toString(Integer.parseInt(hexBlue, 16));
+    }
+
+}

--- a/src/main/java/eu/hansolo/colors/FlatUi.java
+++ b/src/main/java/eu/hansolo/colors/FlatUi.java
@@ -22,32 +22,145 @@ import javafx.scene.paint.Color;
 /**
  * Created by hansolo on 11.01.16.
  */
-public enum FlatUi {
+public enum FlatUi implements IColor {
+    /**
+     * The color TURQOISE with an RGB value of rgb(31, 188, 156).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(31, 188, 156);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TURQOISE(31, 188, 156),
+
+    /**
+     * The color GREEN SEA with an RGB value of rgb(26, 160, 133).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(26, 160, 133);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_SEA(26, 160, 133),
+
+    /**
+     * The color EMERLAND with an RGB value of rgb(87, 214, 141).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(87, 214, 141);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     EMERLAND(87, 214, 141),
+
+    /**
+     * The color NEPHRITIS with an RGB value of rgb(39, 174, 96).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(39, 174, 96);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     NEPHRITIS(39, 174, 96),
+
+    /**
+     * The color PETER RIVER with an RGB value of rgb(92, 172, 226).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(92, 172, 226);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PETER_RIVER(92, 172, 226),
+
+    /**
+     * The color BELIZE_HOLE with an RGB value of rgb(83, 153, 198).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(83, 153, 198);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BELIZE_HOLE(83, 153, 198),
+
+    /**
+     * The color AMETHYST with an RGB value of rgb(175, 122, 196).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(175, 122, 196);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMETHYST(175, 122, 196),
+
+    /**
+     * The color WISTERIA with an RGB value of rgb(142, 68, 173).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(142, 68, 173);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     WISTERIA(142, 68, 173),
+
+    /**
+     * The color SUNFLOWER with an RGB value of rgb(241, 196, 40).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(241, 196, 40);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     SUNFLOWER(241, 196, 40),
+
+    /**
+     * The color ORANGE with an RGB value of rgb(245, 175, 65).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(245, 175, 65);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE(245, 175, 65),
+
+    /**
+     * The color CARROT with an RGB value of rgb(245, 175, 65).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(245, 175, 65);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CARROT(245, 175, 65),
+
+    /**
+     * The color PUMPKIN with an RGB value of rgb(211, 85, 25).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(211, 85, 25);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PUMPKIN(211, 85, 25),
+
+    /**
+     * The color ALIZARIN with an RGB value of rgb(234, 111, 99).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(234, 111, 99);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ALIZARIN(234, 111, 99),
+
+    /**
+     * The color POMEGRANATE with an RGB value of rgb(204, 96, 85).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(204, 96, 85);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     POMEGRANATE(204, 96, 85),
+
+    /**
+     * The color CLOUDS with an RGB value of rgb(239, 243, 243).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(239, 243, 243);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CLOUDS(239, 243, 243),
+
+    /**
+     * The color SILVER with an RGB value of rgb(189, 195, 199).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(189, 195, 199);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     SILVER(189, 195, 199),
+
+    /**
+     * The color CONCRETE with an RGB value of rgb(149, 165, 166).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(149, 165, 166);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CONCRETE(149, 165, 166),
+
+    /**
+     * The color ASBESTOS with an RGB value of rgb(127, 140, 141).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(127, 140, 141);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ASBESTOS(127, 140, 141),
+
+    /**
+     * The color WET ASPHALT with an RGB value of rgb(52, 73, 94).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(52, 73, 94);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     WET_ASPHALT(52, 73, 94),
+
+    /**
+     * The color MIDNIGHT BLUE with an RGB value of rgb(44, 62, 80).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(44, 62, 80);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     MIDNIGHT_BLUE(44, 62, 80);
 
-
-    public final Color COLOR;
+    private final Color COLOR;
 
     FlatUi(final int R, final int G, final int B) {
         COLOR = Color.rgb(R, G, B);
+    }
+
+    @Override
+    public Color get() {
+        return COLOR;
+    }
+
+    @Override
+    public String rgb() {
+        return ColorHelper.rgb(COLOR);
+    }
+
+    @Override
+    public String web() {
+        return ColorHelper.web(COLOR);
     }
 }

--- a/src/main/java/eu/hansolo/colors/FlatUiColorPicker.java
+++ b/src/main/java/eu/hansolo/colors/FlatUiColorPicker.java
@@ -33,10 +33,6 @@ import javafx.stage.Stage;
 import javafx.scene.layout.StackPane;
 import javafx.scene.Scene;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-
 /**
  * User: hansolo
  * Date: 11.01.16
@@ -55,17 +51,13 @@ public class FlatUiColorPicker extends Application {
         int  row  = 0;
         for (FlatUi color : FlatUi.values()) {
             String name     = color.name().replace("_", " ");
-            String hex      = color.COLOR.toString().replace("0x", "");
-            String hexRed   = hex.substring(0, 2).toUpperCase();
-            String hexGreen = hex.substring(2, 4).toUpperCase();
-            String hexBlue  = hex.substring(4, 6).toUpperCase();
-            String intRed   = Integer.toString(Integer.parseInt(hexRed, 16));
-            String intGreen = Integer.toString(Integer.parseInt(hexGreen, 16));
-            String intBlue  = Integer.toString(Integer.parseInt(hexBlue, 16));
+            String strWeb   = ColorHelper.web(color.get());
+            String strRgb   = ColorHelper.rgb(color.get());
             String text     = new StringBuilder().append(name)
                                                  .append("\n")
-                                                 .append("#").append(hexRed).append(hexGreen).append(hexBlue).append("\n")
-                                                 .append("rgb(").append(intRed).append(",").append(intGreen).append(",").append(intBlue).append(")")
+                                                 .append(strWeb)
+                                                 .append("\n")
+                                                 .append(strRgb)
                                                  .toString();
 
             Label label = new Label(name);
@@ -77,22 +69,16 @@ public class FlatUiColorPicker extends Application {
             StackPane box = new StackPane(label);
             box.setPrefSize(BOX_WIDTH, BOX_HEIGHT);
             box.setAlignment(Pos.BOTTOM_LEFT);
-            box.setBackground(new Background(new BackgroundFill(color.COLOR, CornerRadii.EMPTY, Insets.EMPTY)));
+            box.setBackground(new Background(new BackgroundFill(color.get(), CornerRadii.EMPTY, Insets.EMPTY)));
             box.setOnMousePressed(event -> {
                 box.setScaleX(0.9);
                 box.setScaleY(0.9);
-                String clipboardContent = new StringBuilder().append("Color.web(\"#")
-                                                             .append(hexRed)
-                                                             .append(hexGreen)
-                                                             .append(hexBlue)
+                String clipboardContent = new StringBuilder().append("Color.web(\"")
+                                                             .append(strWeb)
                                                              .append("\");\n")
-                                                             .append("Color.rgb(")
-                                                             .append(intRed)
-                                                             .append(", ")
-                                                             .append(intGreen)
-                                                             .append(", ")
-                                                             .append(intBlue)
-                                                             .append(");").toString();
+                                                             .append("Color.")
+                                                             .append(strRgb)
+                                                             .append(";").toString();
 
                 Clipboard        clipboard = Clipboard.getSystemClipboard();
                 ClipboardContent content   = new ClipboardContent();

--- a/src/main/java/eu/hansolo/colors/IColor.java
+++ b/src/main/java/eu/hansolo/colors/IColor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016 by Gerrit Grunwald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.hansolo.colors;
+
+import javafx.scene.paint.Color;
+
+/**
+ *
+ * Created by Naoghuman on 12.01.16.
+ */
+public interface IColor {
+
+    /**
+     * Returns the corresponding JavaFX color.
+     * 
+     * @return the corresponding JavaFX color.
+     */
+    public Color get();
+
+    /**
+     * Returns a String expression from the color with the format: rgb(12, 121, 15)
+     * 
+     * @return the String expression.
+     */
+    public String rgb();
+
+    /**
+     * Returns a String expression from the color with the format: #AB12CD
+     * 
+     * @return the String expression.
+     */
+    public String web();
+}

--- a/src/main/java/eu/hansolo/colors/MaterialDesign.java
+++ b/src/main/java/eu/hansolo/colors/MaterialDesign.java
@@ -22,305 +22,1683 @@ import javafx.scene.paint.Color;
 /**
  * Created by hansolo on 11.01.16.
  */
-public enum MaterialDesign {
+public enum MaterialDesign implements IColor {
     // RED
+    /**
+     * The color RED with an RGB value of rgb(244, 67, 54).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(244, 67, 54);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED(244, 67, 54),
+
+    /**
+     * The color RED 50 with an RGB value of rgb(255, 235, 238).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 235, 238);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_50(255, 235, 238),
+
+    /**
+     * The color RED 100 with an RGB value of rgb(255, 205, 210).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 205, 210);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_100(255, 205, 210),
+
+    /**
+     * The color RED 200 with an RGB value of rgb(239, 154, 154).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(239, 154, 154);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_200(239, 154, 154),
+
+    /**
+     * The color RED 300 with an RGB value of rgb(229, 115, 115).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(229, 115, 115);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_300(229, 115, 115),
+
+    /**
+     * The color RED 400 with an RGB value of rgb(239, 83, 80).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(239, 83, 80);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_400(239, 83, 80),
+
+    /**
+     * The color RED 500 with an RGB value of rgb(244, 67, 54).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(244, 67, 54);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_500(244, 67, 54),
+
+    /**
+     * The color RED 600 with an RGB value of rgb(229, 57, 53).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(229, 57, 53);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_600(229, 57, 53),
+
+    /**
+     * The color RED 700 with an RGB value of rgb(211, 47, 47).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(211, 47, 47);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_700(211, 47, 47),
+
+    /**
+     * The color RED 800 with an RGB value of rgb(198, 40, 40).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(198, 40, 40);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_800(198, 40, 40),
+
+    /**
+     * The color RED 900 with an RGB value of rgb(183, 28, 28).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(183, 28, 28);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_900(183, 28, 28),
+
+    /**
+     * The color RED A100 with an RGB value of rgb(255, 138, 128).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 138, 128);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_A100(255, 138, 128),
+
+    /**
+     * The color RED A200 with an RGB value of rgb(255, 82, 82).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 82, 82);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_A200(255, 82, 82),
+
+    /**
+     * The color RED A400 with an RGB value of rgb(255, 23, 68).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 23, 68);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_A400(255, 23, 68),
+
+    /**
+     * The color RED A700 with an RGB value of rgb(213, 0, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(213, 0, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED_A700(213, 0, 0),
+
     // PINK
+    /**
+     * The color PINK with an RGB value of rgb(233, 30, 99).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(233, 30, 99);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK(233, 30, 99),
+
+    /**
+     * The color PINK 50 with an RGB value of rgb(252, 228, 236).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(252, 228, 236);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_50(252, 228, 236),
+
+    /**
+     * The color PINK 100 with an RGB value of rgb(248, 187, 208).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(248, 187, 208);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_100(248, 187, 208),
+
+    /**
+     * The color PINK 200 with an RGB value of rgb(244, 143, 177).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(244, 143, 177);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_200(244, 143, 177),
+
+    /**
+     * The color PINK 300 with an RGB value of rgb(240, 98, 146).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(240, 98, 146);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_300(240, 98, 146),
+
+    /**
+     * The color PINK 400 with an RGB value of rgb(236, 64, 122).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(236, 64, 122);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_400(236, 64, 122),
+
+    /**
+     * The color PINK 500 with an RGB value of rgb(233, 30, 99).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(233, 30, 99);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_500(233, 30, 99),
+
+    /**
+     * The color PINK 600 with an RGB value of rgb(216, 27, 96).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(216, 27, 96);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_600(216, 27, 96),
+
+    /**
+     * The color PINK 700 with an RGB value of rgb(194, 24, 91).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(194, 24, 91);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_700(194, 24, 91),
+
+    /**
+     * The color PINK 800 with an RGB value of rgb(173, 20, 87).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(173, 20, 87);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_800(173, 20, 87),
+
+    /**
+     * The color PINK 900 with an RGB value of rgb(136, 14, 79).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(136, 14, 79);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_900(136, 14, 79),
+
+    /**
+     * The color PINK A100 with an RGB value of rgb(255, 128, 171).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 128, 171);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_A100(255, 128, 171),
+
+    /**
+     * The color PINK A200 with an RGB value of rgb(255, 64, 129).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 64, 129);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_A200(255, 64, 129),
+
+    /**
+     * The color PINK A400 with an RGB value of rgb(245, 0, 87).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(245, 0, 87);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_A400(245, 0, 87),
+
+    /**
+     * The color PINK A700 with an RGB value of rgb(197, 17, 98).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(197, 17, 98);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINK_A700(197, 17, 98),
+
     // PURPLE
+    /**
+     * The color PURPLE with an RGB value of rgb(156, 39, 176).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(156, 39, 176);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE(156, 39, 176),
+
+    /**
+     * The color PURPLE 50 with an RGB value of rgb(243, 229, 245).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(243, 229, 245);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_50(243, 229, 245),
+
+    /**
+     * The color PURPLE 100 with an RGB value of rgb(225, 190, 231).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(225, 190, 231);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_100(225, 190, 231),
+
+    /**
+     * The color PURPLE 200 with an RGB value of rgb(206, 147, 216).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(206, 147, 216);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_200(206, 147, 216),
+
+    /**
+     * The color PURPLE 300 with an RGB value of rgb(186, 104, 200).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(186, 104, 200);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_300(186, 104, 200),
+
+    /**
+     * The color PURPLE 400 with an RGB value of rgb(171, 71, 188).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(171, 71, 188);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_400(171, 71, 188),
+
+    /**
+     * The color PURPLE 500 with an RGB value of rgb(156, 39, 176).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(156, 39, 176);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_500(156, 39, 176),
+
+    /**
+     * The color PURPLE 600 with an RGB value of rgb(142, 36, 170).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(142, 36, 170);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_600(142, 36, 170),
+
+    /**
+     * The color PURPLE 700 with an RGB value of rgb(123, 31, 162).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(123, 31, 162);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_700(123, 31, 162),
+
+    /**
+     * The color PURPLE 800 with an RGB value of rgb(106, 27, 154).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(106, 27, 154);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_800(106, 27, 154),
+
+    /**
+     * The color PURPLE 900 with an RGB value of rgb(74, 20, 140).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(74, 20, 140);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_900(74, 20, 140),
+
+    /**
+     * The color PURPLE A100 with an RGB value of rgb(234, 128, 252).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(234, 128, 252);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_A100(234, 128, 252),
+
+    /**
+     * The color PURPLE A200 with an RGB value of rgb(224, 64, 251).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(224, 64, 251);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_A200(224, 64, 251),
+
+    /**
+     * The color PURPLE A400 with an RGB value of rgb(213, 0, 249).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(213, 0, 249);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_A400(213, 0, 249),
+
+    /**
+     * The color PURPLE A700 with an RGB value of rgb(170, 0, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(170, 0, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE_A700(170, 0, 255),
+
     // DEEP PURPLE
+    /**
+     * The color DEEP PURPLE with an RGB value of rgb(103, 58, 183).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(103, 58, 183);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE(103, 58, 183),
+
+    /**
+     * The color DEEP PURPLE 50 with an RGB value of rgb(237, 231, 246).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(237, 231, 246);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_50(237, 231, 246),
+
+    /**
+     * The color DEEP PURPLE 100 with an RGB value of rgb(209, 196, 233).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(209, 196, 233);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_100(209, 196, 233),
+
+    /**
+     * The color DEEP PURPLE 200 with an RGB value of rgb(179, 157, 219).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(179, 157, 219);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_200(179, 157, 219),
+
+    /**
+     * The color DEEP PURPLE 300 with an RGB value of rgb(149, 117, 205).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(149, 117, 205);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_300(149, 117, 205),
+
+    /**
+     * The color DEEP PURPLE 400 with an RGB value of rgb(126, 87, 194).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(126, 87, 194);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_400(126, 87, 194),
+
+    /**
+     * The color DEEP PURPLE 500 with an RGB value of rgb(103, 58, 183).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(103, 58, 183);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_500(103, 58, 183),
+
+    /**
+     * The color DEEP PURPLE 600 with an RGB value of rgb(94, 53, 177).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(94, 53, 177);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_600(94, 53, 177),
+
+    /**
+     * The color DEEP PURPLE 700 with an RGB value of rgb(81, 45, 168).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(81, 45, 168);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_700(81, 45, 168),
+
+    /**
+     * The color DEEP PURPLE 800 with an RGB value of rgb(69, 39, 160).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(69, 39, 160);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_800(69, 39, 160),
+
+    /**
+     * The color DEEP PURPLE 900 with an RGB value of rgb(49, 27, 146).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(49, 27, 146);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_900(49, 27, 146),
+
+    /**
+     * The color DEEP PURPLE A100 with an RGB value of rgb(179, 136, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(179, 136, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_A100(179, 136, 255),
+
+    /**
+     * The color DEEP PURPLE A200 with an RGB value of rgb(124, 77, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(124, 77, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_A200(124, 77, 255),
+
+    /**
+     * The color DEEP PURPLE A400 with an RGB value of rgb(101, 31, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(101, 31, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_A400(101, 31, 255),
+
+    /**
+     * The color DEEP PURPLE A700 with an RGB value of rgb(98, 0, 234).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(98, 0, 234);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_PURPLE_A700(98, 0, 234),
+
     // INDIGO
+    /**
+     * The color INDIGO with an RGB value of rgb(63, 81, 181).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(63, 81, 181);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO(63, 81, 181),
+
+    /**
+     * The color INDIGO 50 with an RGB value of rgb(232, 234, 246).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(232, 234, 246);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_50(232, 234, 246),
+
+    /**
+     * The color INDIGO 100 with an RGB value of rgb(197, 202, 233).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(197, 202, 233);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_100(197, 202, 233),
+
+    /**
+     * The color INDIGO 200 with an RGB value of rgb(159, 168, 218).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(159, 168, 218);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_200(159, 168, 218),
+
+    /**
+     * The color INDIGO 300 with an RGB value of rgb(121, 134, 203).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(121, 134, 203);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_300(121, 134, 203),
+
+    /**
+     * The color INDIGO 400 with an RGB value of rgb(92, 107, 192).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(92, 107, 192);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_400(92, 107, 192),
+
+    /**
+     * The color INDIGO 500 with an RGB value of rgb(63, 81, 181).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(63, 81, 181);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_500(63, 81, 181),
+
+    /**
+     * The color INDIGO 600 with an RGB value of rgb(57, 73, 171).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(57, 73, 171);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_600(57, 73, 171),
+
+    /**
+     * The color INDIGO 700 with an RGB value of rgb(48, 63, 159).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(48, 63, 159);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_700(48, 63, 159),
+
+    /**
+     * The color INDIGO 800 with an RGB value of rgb(40, 53, 147).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(40, 53, 147);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_800(40, 53, 147),
+
+    /**
+     * The color INDIGO 900 with an RGB value of rgb(26, 35, 126).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(26, 35, 126);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_900(26, 35, 126),
+
+    /**
+     * The color INDIGO A100 with an RGB value of rgb(140, 158, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(140, 158, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_A100(140, 158, 255),
+
+    /**
+     * The color INDIGO A200 with an RGB value of rgb(83, 109, 254).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(83, 109, 254);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_A200(83, 109, 254),
+
+    /**
+     * The color INDIGO A400 with an RGB value of rgb(61, 90, 254).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(61, 90, 254);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_A400(61, 90, 254),
+
+    /**
+     * The color INDIGO A700 with an RGB value of rgb(48, 79, 254).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(48, 79, 254);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INDIGO_A700(48, 79, 254),
+
     // BLUE
+    /**
+     * The color BLUE with an RGB value of rgb(33, 150, 243).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(33, 150, 243);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE(33, 150, 243),
+
+    /**
+     * The color BLUE 50 with an RGB value of rgb(227, 242, 253).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(227, 242, 253);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_50(227, 242, 253),
+
+    /**
+     * The color BLUE 100 with an RGB value of rgb(187, 222, 251).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(187, 222, 251);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_100(187, 222, 251),
+
+    /**
+     * The color BLUE 200 with an RGB value of rgb(144, 202, 249).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(144, 202, 249);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_200(144, 202, 249),
+
+    /**
+     * The color BLUE 300 with an RGB value of rgb(100, 181, 246).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(100, 181, 246);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_300(100, 181, 246),
+
+    /**
+     * The color BLUE 400 with an RGB value of rgb(66, 165, 245).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(66, 165, 245);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_400(66, 165, 245),
+
+    /**
+     * The color BLUE 500 with an RGB value of rgb(33, 150, 243).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(33, 150, 243);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_500(33, 150, 243),
+
+    /**
+     * The color BLUE 600 with an RGB value of rgb(30, 136, 229).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(30, 136, 229);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_600(30, 136, 229),
+
+    /**
+     * The color BLUE 700 with an RGB value of rgb(25, 118, 210).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(25, 118, 210);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_700(25, 118, 210),
+
+    /**
+     * The color BLUE 800 with an RGB value of rgb(21, 101, 192).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(21, 101, 192);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_800(21, 101, 192),
+
+    /**
+     * The color BLUE 900 with an RGB value of rgb(13, 71, 161).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(13, 71, 161);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_900(13, 71, 161),
+
+    /**
+     * The color BLUE A100 with an RGB value of rgb(130, 177, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(130, 177, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_A100(130, 177, 255),
+
+    /**
+     * The color BLUE A200 with an RGB value of rgb(68, 138, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(68, 138, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_A200(68, 138, 255),
+
+    /**
+     * The color BLUE A400 with an RGB value of rgb(41, 121, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(41, 121, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_A400(41, 121, 255),
+
+    /**
+     * The color BLUE A700 with an RGB value of rgb(41, 98, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(41, 98, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_A700(41, 98, 255),
+
     // LIGHT_BLUE
+    /**
+     * The color LIGHT BLUE with an RGB value of rgb(3, 169, 244).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(3, 169, 244);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE(3, 169, 244),
+
+    /**
+     * The color LIGHT BLUE 50 with an RGB value of rgb(225, 245, 254).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(225, 245, 254);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_50(225, 245, 254),
+
+    /**
+     * The color LIGHT BLUE 100 with an RGB value of rgb(179, 229, 252).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(179, 229, 252);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_100(179, 229, 252),
+
+    /**
+     * The color LIGHT BLUE 200 with an RGB value of rgb(129, 212, 250).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(129, 212, 250);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_200(129, 212, 250),
+
+    /**
+     * The color LIGHT BLUE 300 with an RGB value of rgb(79, 195, 247).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(79, 195, 247);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_300(79, 195, 247),
+
+    /**
+     * The color LIGHT BLUE 400 with an RGB value of rgb(41, 182, 246).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(41, 182, 246);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_400(41, 182, 246),
+
+    /**
+     * The color LIGHT BLUE 500 with an RGB value of rgb(3, 169, 244).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(3, 169, 244);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_500(3, 169, 244),
+
+    /**
+     * The color LIGHT BLUE 600 with an RGB value of rgb(3, 155, 229).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(3, 155, 229);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_600(3, 155, 229),
+
+    /**
+     * The color LIGHT BLUE 700 with an RGB value of rgb(2, 136, 209).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(2, 136, 209);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_700(2, 136, 209),
+
+    /**
+     * The color LIGHT BLUE 800 with an RGB value of rgb(2, 119, 189).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(2, 119, 189);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_800(2, 119, 189),
+
+    /**
+     * The color LIGHT BLUE 900 with an RGB value of rgb(1, 87, 155).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(1, 87, 155);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_900(1, 87, 155),
+
+    /**
+     * The color LIGHT BLUE A100 with an RGB value of rgb(128, 216, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(128, 216, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_A100(128, 216, 255),
+
+    /**
+     * The color LIGHT BLUE A200 with an RGB value of rgb(64, 196, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(64, 196, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_A200(64, 196, 255),
+
+    /**
+     * The color LIGHT BLUE A400 with an RGB value of rgb(0, 176, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 176, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_A400(0, 176, 255),
+
+    /**
+     * The color LIGHT BLUE A700 with an RGB value of rgb(0, 145, 234).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 145, 234);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE_A700(0, 145, 234),
+
     // CYAN
+    /**
+     * The color CYAN with an RGB value of rgb(0, 188, 212).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 188, 212);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN(0, 188, 212),
+
+    /**
+     * The color CYAN 50 with an RGB value of rgb(224, 247, 250).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(224, 247, 250);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_50(224, 247, 250),
+
+    /**
+     * The color CYAN 100 with an RGB value of rgb(178, 235, 242).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(178, 235, 242);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_100(178, 235, 242),
+
+    /**
+     * The color CYAN 200 with an RGB value of rgb(128, 222, 234).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(128, 222, 234);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_200(128, 222, 234),
+
+    /**
+     * The color CYAN 300 with an RGB value of rgb(77, 208, 225).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(77, 208, 225);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_300(77, 208, 225),
+
+    /**
+     * The color CYAN 400 with an RGB value of rgb(38, 198, 218).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(38, 198, 218);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_400(38, 198, 218),
+
+    /**
+     * The color CYAN 500 with an RGB value of rgb(0, 188, 212).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 188, 212);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_500(0, 188, 212),
+
+    /**
+     * The color CYAN 600 with an RGB value of rgb(0, 172, 193).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 172, 193);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_600(0, 172, 193),
+
+    /**
+     * The color CYAN 700 with an RGB value of rgb(0, 151, 167).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 151, 167);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_700(0, 151, 167),
+
+    /**
+     * The color CYAN 800 with an RGB value of rgb(0, 131, 143).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 131, 143);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_800(0, 131, 143),
+
+    /**
+     * The color CYAN 900 with an RGB value of rgb(0, 96, 100).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 96, 100);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_900(0, 96, 100),
+
+    /**
+     * The color CYAN A100 with an RGB value of rgb(132, 255, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(132, 255, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_A100(132, 255, 255),
+
+    /**
+     * The color CYAN A200 with an RGB value of rgb(24, 255, 25).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(24, 255, 25);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_A200(24, 255, 255),
+
+    /**
+     * The color CYAN A400 with an RGB value of rgb(0, 229, 255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 229, 255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_A400(0, 229, 255),
+
+    /**
+     * The color CYAN A700 with an RGB value of rgb(0, 184, 212).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 184, 212);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     CYAN_A700(0, 184, 212),
+
     // TEAL
+    /**
+     * The color TEAL with an RGB value of rgb(0, 150, 136).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 150, 136);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL(0, 150, 136),
+
+    /**
+     * The color TEAL 50 with an RGB value of rgb(224, 242, 241).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(224, 242, 241);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_50(224, 242, 241),
+
+    /**
+     * The color TEAL 100 with an RGB value of rgb(178, 223, 219).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(178, 223, 219);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_100(178, 223, 219),
+
+    /**
+     * The color TEAL 200 with an RGB value of rgb(128, 203, 196).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(128, 203, 196);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_200(128, 203, 196),
+
+    /**
+     * The color TEAL 300 with an RGB value of rgb(77, 182, 172).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(77, 182, 172);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_300(77, 182, 172),
+
+    /**
+     * The color TEAL 400 with an RGB value of rgb(38, 166, 154).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(38, 166, 154);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_400(38, 166, 154),
+
+    /**
+     * The color TEAL 500 with an RGB value of rgb(0, 150, 136).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 150, 136);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_500(0, 150, 136),
+
+    /**
+     * The color TEAL 600 with an RGB value of rgb(0, 137, 123).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 137, 123);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_600(0, 137, 123),
+
+    /**
+     * The color TEAL 700 with an RGB value of rgb(0, 121, 107).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 121, 107);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_700(0, 121, 107),
+
+    /**
+     * The color TEAL 800 with an RGB value of rgb(0, 105, 92).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 105, 92);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_800(0, 105, 92),
+
+    /**
+     * The color TEAL 900 with an RGB value of rgb(0, 77, 64).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 77, 64);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_900(0, 77, 64),
+
+    /**
+     * The color TEAL A100 with an RGB value of rgb(167, 255, 235).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(167, 255, 235);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_A100(167, 255, 235),
+
+    /**
+     * The color TEAL A200 with an RGB value of rgb(100, 255, 218).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(100, 255, 218);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_A200(100, 255, 218),
+
+    /**
+     * The color TEAL A400 with an RGB value of rgb(29, 233, 182).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(29, 233, 182);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_A400(29, 233, 182),
+
+    /**
+     * The color TEAL A700 with an RGB value of rgb(0, 191, 165).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 191, 165);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL_A700(0, 191, 165),
+
     // GREEN
+    /**
+     * The color GREEN with an RGB value of rgb(76, 175, 80).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(76, 175, 80);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN(76, 175, 80),
+
+    /**
+     * The color GREEN 50 with an RGB value of rgb(232, 245, 233).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(232, 245, 233);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_50(232, 245, 233),
+
+    /**
+     * The color GREEN 100 with an RGB value of rgb(200, 230, 201).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(200, 230, 201);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_100(200, 230, 201),
+
+    /**
+     * The color GREEN 200 with an RGB value of rgb(165, 214, 167).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(165, 214, 167);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_200(165, 214, 167),
+
+    /**
+     * The color GREEN 300 with an RGB value of rgb(129, 199, 132).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(129, 199, 132);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_300(129, 199, 132),
+
+    /**
+     * The color GREEN 400 with an RGB value of rgb(102, 187, 106).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(102, 187, 106);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_400(102, 187, 106),
+
+    /**
+     * The color GREEN 500 with an RGB value of rgb(76, 175, 80).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(76, 175, 80);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_500(76, 175, 80),
+
+    /**
+     * The color GREEN 600 with an RGB value of rgb(67, 160, 71).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(67, 160, 71);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_600(67, 160, 71),
+
+    /**
+     * The color GREEN 700 with an RGB value of rgb(56, 142, 60).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(56, 142, 60);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_700(56, 142, 60),
+
+    /**
+     * The color GREEN 800 with an RGB value of rgb(46, 125, 50).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(46, 125, 50);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_800(46, 125, 50),
+
+    /**
+     * The color GREEN 900 with an RGB value of rgb(27, 94, 32).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(27, 94, 32);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_900(27, 94, 32),
+
+    /**
+     * The color GREEN A100 with an RGB value of rgb(185, 246, 202).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(185, 246, 202);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_A100(185, 246, 202),
+
+    /**
+     * The color GREEN A200 with an RGB value of rgb(105, 240, 174).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(105, 240, 174);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_A200(105, 240, 174),
+
+    /**
+     * The color GREEN A400 with an RGB value of rgb(0, 230, 118).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 230, 118);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_A400(0, 230, 118),
+
+    /**
+     * The color GREEN A700 with an RGB value of rgb(0, 200, 83).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0, 200, 83);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN_A700(0, 200, 83),
+
     // LIGHT_GREEN
+    /**
+     * The color LIGHT GREEN with an RGB value of rgb(139, 195, 74).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(139, 195, 74);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN(139, 195, 74),
+
+    /**
+     * The color LIGHT GREEN 50 with an RGB value of rgb(241, 248, 233).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(241, 248, 233);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_50(241, 248, 233),
+
+    /**
+     * The color LIGHT GREEN 100 with an RGB value of rgb(220, 237, 200).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(220, 237, 200);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_100(220, 237, 200),
+
+    /**
+     * The color LIGHT GREEN 200 with an RGB value of rgb(197, 225, 165).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(197, 225, 165);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_200(197, 225, 165),
+
+    /**
+     * The color LIGHT GREEN 300 with an RGB value of rgb(174, 213, 129).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(174, 213, 129);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_300(174, 213, 129),
+
+    /**
+     * The color LIGHT GREEN 400 with an RGB value of rgb(156, 204, 101).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(156, 204, 101);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_400(156, 204, 101),
+
+    /**
+     * The color LIGHT GREEN 500 with an RGB value of rgb(139, 195, 74).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(139, 195, 74);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_500(139, 195, 74),
+
+    /**
+     * The color LIGHT GREEN 600 with an RGB value of rgb(124, 179, 66).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(124, 179, 66);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_600(124, 179, 66),
+
+    /**
+     * The color LIGHT GREEN 700 with an RGB value of rgb(104, 159, 56).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(104, 159, 56);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_700(104, 159, 56),
+
+    /**
+     * The color LIGHT GREEN 800 with an RGB value of rgb(85, 139, 47).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(85, 139, 47);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_800(85, 139, 47),
+
+    /**
+     * The color LIGHT GREEN 900 with an RGB value of rgb(51, 105, 30).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(51, 105, 30);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_900(51, 105, 30),
+
+    /**
+     * The color LIGHT GREEN A100 with an RGB value of rgb(204, 255, 144).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(204, 255, 144);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_A100(204, 255, 144),
+
+    /**
+     * The color LIGHT GREEN A200 with an RGB value of rgb(178, 255, 89).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(178, 255, 89);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_A200(178, 255, 89),
+
+    /**
+     * The color LIGHT GREEN A400 with an RGB value of rgb(118, 255, 3).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(118, 255, 3);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_A400(118, 255, 3),
+
+    /**
+     * The color LIGHT GREEN A700 with an RGB value of rgb(100, 221, 23).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(100, 221, 23);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN_A700(100, 221, 23),
+
     //LIME
+    /**
+     * The color LIME with an RGB value of rgb(205, 220, 57).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(205, 220, 57);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME(205, 220, 57),
+
+    /**
+     * The color LIME 50 with an RGB value of rgb(249, 251, 231).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(249, 251, 231);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_50(249, 251, 231),
+
+    /**
+     * The color LIME 100 with an RGB value of rgb(240, 244, 195).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(240, 244, 195);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_100(240, 244, 195),
+
+    /**
+     * The color LIME 200 with an RGB value of rgb(230, 238, 156).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(230, 238, 156);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_200(230, 238, 156),
+
+    /**
+     * The color LIME 300 with an RGB value of rgb(220, 231, 117).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(220, 231, 117);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_300(220, 231, 117),
+
+    /**
+     * The color LIME 400 with an RGB value of rgb(212, 225, 87).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(212, 225, 87);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_400(212, 225, 87),
+
+    /**
+     * The color LIME 500 with an RGB value of rgb(205, 220, 57).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(205, 220, 57);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_500(205, 220, 57),
+
+    /**
+     * The color LIME 600 with an RGB value of rgb(192, 202, 51).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(192, 202, 51);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_600(192, 202, 51),
+
+    /**
+     * The color LIME 700 with an RGB value of rgb(175, 180, 43).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(175, 180, 43);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_700(175, 180, 43),
+
+    /**
+     * The color LIME 800 with an RGB value of rgb(158, 157, 36).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(158, 157, 36);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_800(158, 157, 36),
+
+    /**
+     * The color LIME 900 with an RGB value of rgb(130, 119, 23).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(130, 119, 23);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_900(130, 119, 23),
+
+    /**
+     * The color LIME A100 with an RGB value of rgb(244, 255, 129).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(244, 255, 129);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_A100(244, 255, 129),
+
+    /**
+     * The color LIME A200 with an RGB value of rgb(238, 255, 65).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(238, 255, 65);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_A200(238, 255, 65),
+
+    /**
+     * The color LIME A400 with an RGB value of rgb(198, 255, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(198, 255, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_A400(198, 255, 0),
+
+    /**
+     * The color LIME A700 with an RGB value of rgb(174, 234, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(174, 234, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIME_A700(174, 234, 0),
+
     // YELLOW
+    /**
+     * The color YELLOW with an RGB value of rgb(255, 235, 59).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 235, 59);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW(255, 235, 59),
+
+    /**
+     * The color YELLOW 50 with an RGB value of rgb(255, 253, 231).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 253, 231);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_50(255, 253, 231),
+
+    /**
+     * The color YELLOW 100 with an RGB value of rgb(255, 249, 196).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 249, 196);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_100(255, 249, 196),
+
+    /**
+     * The color YELLOW 200 with an RGB value of rgb(255, 245, 157).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 245, 157);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_200(255, 245, 157),
+
+    /**
+     * The color YELLOW 300 with an RGB value of rgb(255, 241, 118).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 241, 118);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_300(255, 241, 118),
+
+    /**
+     * The color YELLOW 400 with an RGB value of rgb(255, 238, 88).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 238, 88);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_400(255, 238, 88),
+
+    /**
+     * The color YELLOW 500 with an RGB value of rgb(255, 235, 59).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 235, 59);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_500(255, 235, 59),
+
+    /**
+     * The color YELLOW 600 with an RGB value of rgb(253, 216, 53).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(253, 216, 53);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_600(253, 216, 53),
+
+    /**
+     * The color YELLOW 700 with an RGB value of rgb(251, 192, 45).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(251, 192, 45);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_700(251, 192, 45),
+
+    /**
+     * The color YELLOW 800 with an RGB value of rgb(249, 168, 37).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(249, 168, 37);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_800(249, 168, 37),
+
+    /**
+     * The color YELLOW 900 with an RGB value of rgb(245, 127, 23).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(245, 127, 23);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_900(245, 127, 23),
+
+    /**
+     * The color YELLOW A100 with an RGB value of rgb(255, 255, 141).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 255, 141);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_A100(255, 255, 141),
+
+    /**
+     * The color YELLOW A200 with an RGB value of rgb(255, 255, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 255, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_A200(255, 255, 0),
+
+    /**
+     * The color YELLOW A400 with an RGB value of rgb(255, 234, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 234, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_A400(255, 234, 0),
+
+    /**
+     * The color YELLOW A700 with an RGB value of rgb(255, 214, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 214, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW_A700(255, 214, 0),
+
     // AMBER
+    /**
+     * The color AMBER with an RGB value of rgb(255, 193, 7).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 193, 7);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER(255, 193, 7),
+
+    /**
+     * The color AMBER 50 with an RGB value of rgb(255, 248, 225).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 248, 225);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_50(255, 248, 225),
+
+    /**
+     * The color AMBER 100 with an RGB value of rgb(255, 249, 196).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 249, 196);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_100(255, 249, 196),
+
+    /**
+     * The color AMBER 200 with an RGB value of rgb(255, 224, 130).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 224, 130);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_200(255, 224, 130),
+
+    /**
+     * The color AMBER 300 with an RGB value of rgb(255, 213, 79).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 213, 79);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_300(255, 213, 79),
+
+    /**
+     * The color AMBER 400 with an RGB value of rgb(255, 202, 40).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 202, 40);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_400(255, 202, 40),
+
+    /**
+     * The color AMBER 500 with an RGB value of rgb(255, 193, 7).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 193, 7);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_500(255, 193, 7),
+
+    /**
+     * The color AMBER 600 with an RGB value of rgb(255, 179, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 179, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_600(255, 179, 0),
+
+    /**
+     * The color AMBER 700 with an RGB value of rgb(255, 160, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 160, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_700(255, 160, 0),
+
+    /**
+     * The color AMBER 800 with an RGB value of rgb(255, 143, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 143, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_800(255, 143, 0),
+
+    /**
+     * The color AMBER 900 with an RGB value of rgb(255, 111, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 111, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_900(255, 111, 0),
+
+    /**
+     * The color AMBER A100 with an RGB value of rgb(255, 229, 127).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 229, 127);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_A100(255, 229, 127),
+
+    /**
+     * The color AMBER A200 with an RGB value of rgb(255, 215, 64).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 215, 64);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_A200(255, 215, 64),
+
+    /**
+     * The color AMBER A400 with an RGB value of rgb(255, 196, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 196, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_A400(255, 196, 0),
+
+    /**
+     * The color AMBER A700 with an RGB value of rgb(255, 171, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 171, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     AMBER_A700(255, 171, 0),
+
     // ORANGE
+    /**
+     * The color ORANGE with an RGB value of rgb(255, 152, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 152, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE(255, 152, 0),
+
+    /**
+     * The color ORANGE 50 with an RGB value of rgb(255, 243, 224).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 243, 224);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_50(255, 243, 224),
+
+    /**
+     * The color ORANGE 100 with an RGB value of rgb(255, 224, 178).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 224, 178);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_100(255, 224, 178),
+
+    /**
+     * The color ORANGE 200 with an RGB value of rgb(255, 204, 128).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 204, 128);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_200(255, 204, 128),
+
+    /**
+     * The color ORANGE 300 with an RGB value of rgb(255, 183, 77).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 183, 77);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_300(255, 183, 77),
+
+    /**
+     * The color ORANGE 400 with an RGB value of rgb(255, 167, 38).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 167, 38);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_400(255, 167, 38),
+
+    /**
+     * The color ORANGE 500 with an RGB value of rgb(255, 152, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 152, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_500(255, 152, 0),
+
+    /**
+     * The color ORANGE 600 with an RGB value of rgb(251, 140, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(251, 140, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_600(251, 140, 0),
+
+    /**
+     * The color ORANGE 700 with an RGB value of rgb(245, 124, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(245, 124, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_700(245, 124, 0),
+
+    /**
+     * The color ORANGE 800 with an RGB value of rgb(239, 108, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(239, 108, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_800(239, 108, 0),
+
+    /**
+     * The color ORANGE 900 with an RGB value of rgb(230, 81, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(230, 81, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_900(230, 81, 0),
+
+    /**
+     * The color ORANGE A100 with an RGB value of rgb(255, 209, 128).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 209, 128);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_A100(255, 209, 128),
+
+    /**
+     * The color ORANGE A200 with an RGB value of rgb(255, 171, 64).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 171, 64);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_A200(255, 171, 64),
+
+    /**
+     * The color ORANGE A400 with an RGB value of rgb(255, 145, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 145, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_A400(255, 145, 0),
+
+    /**
+     * The color ORANGE A700 with an RGB value of rgb(255, 109, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 109, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE_A700(255, 109, 0),
+
     // DEEP_ORANGE
+    /**
+     * The color DEEP ORANGE with an RGB value of rgb(255, 87, 34).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 87, 34);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE(255, 87, 34),
+
+    /**
+     * The color DEEP ORANGE 50 with an RGB value of rgb(251, 233, 231).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(251, 233, 231);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_50(251, 233, 231),
+
+    /**
+     * The color DEEP ORANGE 100 with an RGB value of rgb(255, 204, 188).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 204, 188);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_100(255, 204, 188),
+
+    /**
+     * The color DEEP ORANGE 200 with an RGB value of rgb(255, 171, 145).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 171, 145);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_200(255, 171, 145),
+
+    /**
+     * The color DEEP ORANGE 300 with an RGB value of rgb(255, 138, 101).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 138, 101);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_300(255, 138, 101),
+
+    /**
+     * The color DEEP ORANGE 400 with an RGB value of rgb(255, 112, 67).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 112, 67);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_400(255, 112, 67),
+
+    /**
+     * The color DEEP ORANGE 500 with an RGB value of rgb(255, 87, 34).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 87, 34);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_500(255, 87, 34),
+
+    /**
+     * The color DEEP ORANGE 600 with an RGB value of rgb(244, 81, 30).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(244, 81, 30);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_600(244, 81, 30),
+
+    /**
+     * The color DEEP ORANGE 700 with an RGB value of rgb(230, 74, 25).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(230, 74, 25);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_700(230, 74, 25),
+
+    /**
+     * The color DEEP ORANGE 800 with an RGB value of rgb(216, 67, 21).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(216, 67, 21);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_800(216, 67, 21),
+
+    /**
+     * The color DEEP ORANGE 900 with an RGB value of rgb(191, 54, 12).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(191, 54, 12);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_900(191, 54, 12),
+
+    /**
+     * The color DEEP ORANGE A100 with an RGB value of rgb(255, 158, 128).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 158, 128);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_A100(255, 158, 128),
+
+    /**
+     * The color DEEP ORANGE A200 with an RGB value of rgb(255, 110, 64).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 110, 64);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_A200(255, 110, 64),
+
+    /**
+     * The color DEEP ORANGE A400 with an RGB value of rgb(255, 61, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255, 61, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_A400(255, 61, 0),
+
+    /**
+     * The color DEEP ORANGE A700 with an RGB value of rgb(221, 44, 0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(221, 44, 0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DEEP_ORANGE_A700(221, 44, 0),
+
     // BROWN
+    /**
+     * The color BROWN with an RGB value of rgb(121, 85, 72).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(121, 85, 72);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN(121, 85, 72),
+
+    /**
+     * The color BROWN 50 with an RGB value of rgb(239, 235, 233).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(239, 235, 233);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_50(239, 235, 233),
+
+    /**
+     * The color BROWN 100 with an RGB value of rgb(215, 204, 200).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(215, 204, 200);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_100(215, 204, 200),
+
+    /**
+     * The color BROWN 200 with an RGB value of rgb(188, 170, 164).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(188, 170, 164);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_200(188, 170, 164),
+
+    /**
+     * The color BROWN 300 with an RGB value of rgb(161, 136, 127).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(161, 136, 127);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_300(161, 136, 127),
+
+    /**
+     * The color BROWN 400 with an RGB value of rgb(141, 110, 99).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(141, 110, 99);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_400(141, 110, 99),
+
+    /**
+     * The color BROWN 500 with an RGB value of rgb(121, 85, 72).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(121, 85, 72);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_500(121, 85, 72),
+
+    /**
+     * The color BROWN 600 with an RGB value of rgb(109, 76, 65).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(109, 76, 65);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_600(109, 76, 65),
+
+    /**
+     * The color BROWN 700 with an RGB value of rgb(93, 64, 55).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(93, 64, 55);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_700(93, 64, 55),
+
+    /**
+     * The color BROWN 800 with an RGB value of rgb(78, 52, 46).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(78, 52, 46);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_800(78, 52, 46),
+
+    /**
+     * The color BROWN 900 with an RGB value of rgb(62, 39, 35).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(62, 39, 35);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BROWN_900(62, 39, 35),
+
     // GREY
+    /**
+     * The color GREY with an RGB value of rgb(158, 158, 158).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(158, 158, 158);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY(158, 158, 158),
+
+    /**
+     * The color GREY 50 with an RGB value of rgb(250, 250, 250).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(250, 250, 250);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_50(250, 250, 250),
+
+    /**
+     * The color GREY 100 with an RGB value of rgb(245, 245, 245).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(245, 245, 245);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_100(245, 245, 245),
+
+    /**
+     * The color GREY 200 with an RGB value of rgb(238, 238, 238).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(238, 238, 238);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_200(238, 238, 238),
+
+    /**
+     * The color GREY 300 with an RGB value of rgb(224, 224, 224).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(224, 224, 224);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_300(224, 224, 224),
+
+    /**
+     * The color GREY 400 with an RGB value of rgb(189, 189, 189).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(189, 189, 189);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_400(189, 189, 189),
+
+    /**
+     * The color GREY 500 with an RGB value of rgb(158, 158, 158).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(158, 158, 158);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_500(158, 158, 158),
+
+    /**
+     * The color GREY 600 with an RGB value of rgb(117, 117, 117).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(117, 117, 117);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_600(117, 117, 117),
+
+    /**
+     * The color GREY 700 with an RGB value of rgb(97, 97, 97).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(97, 97, 97);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_700(97, 97, 97),
+
+    /**
+     * The color GREY 800 with an RGB value of rgb(66, 66, 66).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(66, 66, 66);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_800(66, 66, 66),
+
+    /**
+     * The color GREY 900 with an RGB value of rgb(33, 33, 33).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(33, 33, 33);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREY_900(33, 33, 33),
+
     // BLUE GREY
+    /**
+     * The color BLUE GREY with an RGB value of rgb(96, 125, 139).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(96, 125, 139);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY(96, 125, 139),
+
+    /**
+     * The color BLUE GREY 50 with an RGB value of rgb(236, 239, 241).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(236, 239, 241);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_50(236, 239, 241),
+
+    /**
+     * The color BLUE GREY 100 with an RGB value of rgb(207, 216, 220).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(207, 216, 220);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_100(207, 216, 220),
+
+    /**
+     * The color BLUE GREY 200 with an RGB value of rgb(176, 190, 197).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(176, 190, 197);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_200(176, 190, 197),
+
+    /**
+     * The color BLUE GREY 300 with an RGB value of rgb(144, 164, 174).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(144, 164, 174);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_300(144, 164, 174),
+
+    /**
+     * The color BLUE GREY 400 with an RGB value of rgb(120, 144, 156).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(120, 144, 156);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_400(120, 144, 156),
+
+    /**
+     * The color BLUE GREY 500 with an RGB value of rgb(96, 125, 139).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(96, 125, 139);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_500(96, 125, 139),
+
+    /**
+     * The color BLUE GREY 600 with an RGB value of rgb(84, 110, 122).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(84, 110, 122);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_600(84, 110, 122),
+
+    /**
+     * The color BLUE GREY 700 with an RGB value of rgb(69, 90, 100).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(69, 90, 100);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_700(69, 90, 100),
+
+    /**
+     * The color BLUE GREY 800 with an RGB value of rgb(55, 71, 79).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(55, 71, 79);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_800(55, 71, 79),
+
+    /**
+     * The color BLUE GREY 900 with an RGB value of rgb(38, 50, 56).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(38, 50, 56);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE_GREY_900(38, 50, 56);
 
-
-    public final Color COLOR;
+    private final Color COLOR;
 
     MaterialDesign(final int RED, final int GREEN, final int BLUE) {
         COLOR = Color.rgb(RED, GREEN, BLUE);
+    }
+
+    @Override
+    public Color get() {
+        return COLOR;
+    }
+
+    @Override
+    public String rgb() {
+        return ColorHelper.rgb(COLOR);
+    }
+
+    @Override
+    public String web() {
+        return ColorHelper.web(COLOR);
     }
 }
 

--- a/src/main/java/eu/hansolo/colors/MaterialDesignColorPicker.java
+++ b/src/main/java/eu/hansolo/colors/MaterialDesignColorPicker.java
@@ -39,7 +39,6 @@ import javafx.scene.Scene;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 /**
  * User: hansolo
  * Date: 11.01.16
@@ -60,17 +59,13 @@ public class MaterialDesignColorPicker extends Application {
         int  row  = 0;
         for (MaterialDesign color : MaterialDesign.values()) {
             String name     = color.name().replace("_", " ");
-            String hex      = color.COLOR.toString().replace("0x", "");
-            String hexRed   = hex.substring(0, 2).toUpperCase();
-            String hexGreen = hex.substring(2, 4).toUpperCase();
-            String hexBlue  = hex.substring(4, 6).toUpperCase();
-            String intRed   = Integer.toString(Integer.parseInt(hexRed, 16));
-            String intGreen = Integer.toString(Integer.parseInt(hexGreen, 16));
-            String intBlue  = Integer.toString(Integer.parseInt(hexBlue, 16));
+            String strWeb   = ColorHelper.web(color.get());
+            String strRgb   = ColorHelper.rgb(color.get());
             String text     = new StringBuilder().append(name)
                                                  .append("\n")
-                                                 .append("#").append(hexRed).append(hexGreen).append(hexBlue).append("\n")
-                                                 .append("rgb(").append(intRed).append(",").append(intGreen).append(",").append(intBlue).append(")")
+                                                 .append(strWeb)
+                                                 .append("\n")
+                                                 .append(strRgb)
                                                  .toString();
             MATCHER.reset(color.name());
             String brightness = "";
@@ -87,22 +82,16 @@ public class MaterialDesignColorPicker extends Application {
             StackPane box = new StackPane(label);
             box.setPrefSize(BOX_WIDTH, BOX_HEIGHT);
             box.setAlignment(Pos.BOTTOM_LEFT);
-            box.setBackground(new Background(new BackgroundFill(color.COLOR, CornerRadii.EMPTY, Insets.EMPTY)));
+            box.setBackground(new Background(new BackgroundFill(color.get(), CornerRadii.EMPTY, Insets.EMPTY)));
             box.setOnMousePressed(event -> {
                 box.setScaleX(0.9);
                 box.setScaleY(0.9);
-                String clipboardContent = new StringBuilder().append("Color.web(\"#")
-                                                             .append(hexRed)
-                                                             .append(hexGreen)
-                                                             .append(hexBlue)
+                String clipboardContent = new StringBuilder().append("Color.web(\"")
+                                                             .append(strWeb)
                                                              .append("\");\n")
-                                                             .append("Color.rgb(")
-                                                             .append(intRed)
-                                                             .append(", ")
-                                                             .append(intGreen)
-                                                             .append(", ")
-                                                             .append(intBlue)
-                                                             .append(");").toString();
+                                                             .append("Color.")
+                                                             .append(strRgb)
+                                                             .append(";").toString();
 
                 Clipboard        clipboard  = Clipboard.getSystemClipboard();
                 ClipboardContent content    = new ClipboardContent();

--- a/src/main/java/eu/hansolo/colors/Metro.java
+++ b/src/main/java/eu/hansolo/colors/Metro.java
@@ -22,29 +22,128 @@ import javafx.scene.paint.Color;
 /**
  * Created by hansolo on 11.01.16.
  */
-public enum Metro {
+public enum Metro implements IColor {
+
+    /**
+     * The color LIGHT GREEN with an RGB value of rgb(153,180,51).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(153,180,51);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_GREEN(153,180,51),
+
+    /**
+     * The color GREEN with an RGB value of rgb(0,163,0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0,163,0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GREEN(0,163,0),
+
+    /**
+     * The color DARK GREEN with an RGB value of rgb(30,113,69).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(30,113,69);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DARK_GREEN(30,113,69),
+
+    /**
+     * The color MAGENTA with an RGB value of rgb(255,0,151).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255,0,151);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     MAGENTA(255,0,151),
+
+    /**
+     * The color LIGHT PURPLE with an RGB value of rgb(159,0,167).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(159,0,167);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_PURPLE(159,0,167),
+
+    /**
+     * The color PURPLE with an RGB value of rgb(126,56,120).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(126,56,120);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PURPLE(126,56,120),
+
+    /**
+     * The color DARK PURPLE with an RGB value of rgb(96,60,186).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(96,60,186);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DARK_PURPLE(96,60,186),
+
+    /**
+     * The color DARKEN with an RGB value of rgb(29,29,29).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(29,29,29);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DARKEN(29,29,29),
+
+    /**
+     * The color TEAL with an RGB value of rgb(0,171,169).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0,171,169);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TEAL(0,171,169),
+
+    /**
+     * The color LIGHT BLUE with an RGB value of rgb(239,244,255).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(239,244,255);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LIGHT_BLUE(239,244,255),
+
+    /**
+     * The color BLUE with an RGB value of rgb(45,137,239).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(45,137,239);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BLUE(45,137,239),
+
+    /**
+     * The color DARK BLUE with an RGB value of rgb(43,87,151).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(43,87,151);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DARK_BLUE(43,87,151),
+
+    /**
+     * The color YELLOW with an RGB value of rgb(255,196,13).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255,196,13);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YELLOW(255,196,13),
+
+    /**
+     * The color ORANGE with an RGB value of rgb(227,162,26).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(227,162,26);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     ORANGE(227,162,26),
+
+    /**
+     * The color DARK ORANGE with an RGB value of rgb(218,83,44).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(218,83,44);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DARK_ORANGE(218,83,44),
+
+    /**
+     * The color RED with an RGB value of rgb(238,17,17).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(238,17,17);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     RED(238,17,17),
+
+    /**
+     * The color DARK RED with an RGB value of rgb(185,29,71).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(185,29,71);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DARK_RED(185,29,71);
 
-
-    public final Color COLOR;
+    private final Color COLOR;
 
     Metro(final int R, final int G, final int B) {
         COLOR = Color.rgb(R, G, B);
+    }
+
+    @Override
+    public Color get() {
+        return COLOR;
+    }
+
+    @Override
+    public String rgb() {
+        return ColorHelper.rgb(COLOR);
+    }
+
+    @Override
+    public String web() {
+        return ColorHelper.web(COLOR);
     }
 }

--- a/src/main/java/eu/hansolo/colors/Social.java
+++ b/src/main/java/eu/hansolo/colors/Social.java
@@ -22,42 +22,206 @@ import javafx.scene.paint.Color;
 /**
  * Created by hansolo on 11.01.16.
  */
-public enum Social {
+public enum Social implements IColor {
+
+    /**
+     * The color FACEBOOK with an RGB value of rgb(59,89,153).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(59,89,153);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     FACEBOOK(59,89,153),
+
+    /**
+     * The color TWITTER with an RGB value of rgb(85,172,238).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(85,172,238);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TWITTER(85,172,238),
+
+    /**
+     * The color LINKED IN with an RGB value of rgb(0,119,181).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0,119,181);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     LINKED_IN(0,119,181),
+
+    /**
+     * The color TUMBLR with an RGB value of rgb(52,70,93).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(52,70,93);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     TUMBLR(52,70,93),
+
+    /**
+     * The color YAHOO with an RGB value of rgb(65,0,147).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(65,0,147);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YAHOO(65,0,147),
+
+    /**
+     * The color INSTAGRAM with an RGB value of rgb().
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb();float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     INSTAGRAM(63,114,155),
+
+    /**
+     * The color SKYPE with an RGB value of rgb(0,175,240).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0,175,240);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     SKYPE(0,175,240),
+
+    /**
+     * The color WORDPRESS with an RGB value of rgb(33,117,155).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(33,117,155);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     WORDPRESS(33,117,155),
+
+    /**
+     * The color VIMEO with an RGB value of rgb(26,183,234).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(26,183,234);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     VIMEO(26,183,234),
+
+    /**
+     * The color VK with an RGB value of rgb(76,117,163).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(76,117,163);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     VK(76,117,163),
+
+    /**
+     * The color SLIDE_SHARE with an RGB value of rgb(0,119,181).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0,119,181);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     SLIDE_SHARE(0,119,181),
+
+    /**
+     * The color GOOGLE PLUS with an RGB value of rgb(220,78,65).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(220,78,65);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     GOOGLE_PLUS(220,78,65),
+
+    /**
+     * The color PINTEREST with an RGB value of rgb(189,8,28).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(189,8,28);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PINTEREST(189,8,28),
+
+    /**
+     * The color YOUTUBE with an RGB value of rgb(229,45,39).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(229,45,39);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     YOUTUBE(229,45,39),
+
+    /**
+     * The color STUMBLE UPON with an RGB value of rgb(235,73,36).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(235,73,36);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     STUMBLE_UPON(235,73,36),
+
+    /**
+     * The color REDDIT with an RGB value of rgb(255,87,0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255,87,0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     REDDIT(255,87,0),
+
+    /**
+     * The color QUORA with an RGB value of rgb(185,43,39).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(185,43,39);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     QUORA(185,43,39),
+
+    /**
+     * The color WEIBO with an RGB value of rgb(223,32,41).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(223,32,41);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     WEIBO(223,32,41),
+
+    /**
+     * The color PRODUCT HUNT with an RGB value of rgb(218,85,47).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(218,85,47);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     PRODUCT_HUNT(218,85,47),
+
+    /**
+     * The color HACKER NEWS with an RGB value of rgb(255,102,0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255,102,0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     HACKER_NEWS(255,102,0),
+
+    /**
+     * The color WHATS APP with an RGB value of rgb(37,211,102).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(37,211,102);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     WHATS_APP(37,211,102),
+
+    /**
+     * The color WE CHAT with an RGB value of rgb(9,184,62).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(9,184,62);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     WE_CHAT(9,184,62),
+
+    /**
+     * The color MEDIUM with an RGB value of rgb(2,184,117).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(2,184,117);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     MEDIUM(2,184,117),
+
+    /**
+     * The color VINE with an RGB value of rgb(0,180,137).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(0,180,137);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     VINE(0,180,137),
+
+    /**
+     * The color SLACK with an RGB value of rgb(58,175,133).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(58,175,133);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     SLACK(58,175,133),
+
+    /**
+     * The color DRIBBLE with an RGB value of rgb(234,76,137).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(234,76,137);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     DRIBBLE(234,76,137),
+
+    /**
+     * The color FLICKR with an RGB value of rgb(255,0,132).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255,0,132);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     FLICKR(255,0,132),
+
+    /**
+     * The color FOUR SQUARE with an RGB value of rgb(249,72,119).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(249,72,119);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     FOUR_SQUARE(249,72,119),
+
+    /**
+     * The color BEHANCE with an RGB value of rgb(19,20,24).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(19,20,24);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     BEHANCE(19,20,24),
+
+    /**
+     * The color SNAP CHAT with an RGB value of rgb(255,252,0).
+     * <div style="border:1px solid black;width:40px;height:20px;background-color:rgb(255,252,0);float:right;margin: 0 10px 0 0"></div><br/><br/>
+     */
     SNAP_CHAT(255,252,0);
 
-
-    public final Color COLOR;
+    private final Color COLOR;
 
     Social(final int R, final int G, final int B) {
         COLOR = Color.rgb(R, G, B);
+    }
+
+    @Override
+    public Color get() {
+        return COLOR;
+    }
+
+    @Override
+    public String rgb() {
+        return ColorHelper.rgb(COLOR);
+    }
+
+    @Override
+    public String web() {
+        return ColorHelper.web(COLOR);
     }
 }


### PR DESCRIPTION
Hi Gerrit,
I really like colors :) . Your projects also :)) .

I like the idea to have a little library which contains popular color definitions. I have done a little extention, so the user can now see over the JavaDoc (like in JavaFX Color class). So its now also possible with the Code-Completion dialog in the IDE to see the corresponding color from the selection of a enum value.

What I have done:
- Add JavaDoc to every enum value which allows the user to see the color.
- Add interface IColor with additional methods to access the color.
- Define new class ColorHelper which converts the JavaFX color to the String expression (rgb, hex)
- Refactore the XyColorPicker so they suit with the new functionalities.

**Hm**, I see that I have accidently changed the gitignore file. NetBeans have added automatically the flag /.nb-gradle/. Plz skip it if its not okay.

Greetings
Peter
